### PR TITLE
Add sha384 RSA & ECDSA algorithms support

### DIFF
--- a/src/common/ocsp.rs
+++ b/src/common/ocsp.rs
@@ -4,7 +4,7 @@ use asn1_der::DerObject;
 use tracing::{error, trace};
 
 use crate::common::asn1::{
-    TryIntoSequence, ASN1_EXPLICIT_0, ASN1_EXPLICIT_1, ASN1_EXPLICIT_2, ASN1_NULL, ASN1_OID
+    TryIntoSequence, ASN1_EXPLICIT_0, ASN1_EXPLICIT_1, ASN1_EXPLICIT_2, ASN1_NULL, ASN1_OID,
 };
 use crate::{err::OcspError, oid::*};
 

--- a/src/common/ocsp.rs
+++ b/src/common/ocsp.rs
@@ -4,7 +4,7 @@ use asn1_der::DerObject;
 use tracing::{error, trace};
 
 use crate::common::asn1::{
-    asn1_encode_bit_string, TryIntoSequence, ASN1_BIT_STRING, ASN1_EXPLICIT_0, ASN1_EXPLICIT_1, ASN1_EXPLICIT_2, ASN1_INTEGER, ASN1_NULL, ASN1_OCTET, ASN1_OID
+    TryIntoSequence, ASN1_EXPLICIT_0, ASN1_EXPLICIT_1, ASN1_EXPLICIT_2, ASN1_NULL, ASN1_OID
 };
 use crate::{err::OcspError, oid::*};
 

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -312,7 +312,9 @@ mod test {
     // Test oid to DER
     #[test]
     fn test_oid2binary() {
-        let oid = &Oid { index: ALGO_SHA384_WITH_RSA_ENCRYPTION_ID };
+        let oid = &Oid {
+            index: ALGO_SHA384_WITH_RSA_ENCRYPTION_ID,
+        };
         let hex = i2b_oid(oid).unwrap();
         assert_eq!(hex, ALGO_SHA384_WITH_RSA_ENCRYPTION_HEX);
     }

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -294,4 +294,12 @@ mod test {
         let oid = d2i_oid(dot);
         assert!(oid.is_none());
     }
+
+    // Test oid to DER
+    #[test]
+    fn test_oid2binary() {
+        let oid = &Oid { index: ALGO_SHA384_WITH_RSA_ENCRYPTION_ID };
+        let hex = i2b_oid(oid).unwrap();
+        assert_eq!(hex, ALGO_SHA384_WITH_RSA_ENCRYPTION_HEX);
+    }
 }

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -274,9 +274,9 @@ mod test {
     // test dot notation to oid
     #[test]
     fn test_dot2oid() {
-        let dot = OCSP_EXT_EXTENDED_REVOKE_DOT;
+        let dot = ALGO_SHA384_WITH_RSA_ENCRYPTION_DOT;
         let oid = d2i_oid(dot).unwrap().index;
-        assert_eq!(oid, OCSP_EXT_EXTENDED_REVOKE_ID);
+        assert_eq!(oid, ALGO_SHA384_WITH_RSA_ENCRYPTION_ID);
     }
 
     // test dot to oid return None for unknown id

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -177,6 +177,16 @@ pub const ALGO_SHA256_WITH_ECDSA_ENCRYPTION_NAME: &str =
 /// OID_MAX_ID = 3
 pub(crate) const OID_MAX_ID: usize = 13;
 
+pub(crate) const ALGO_SHA384_WITH_RSA_ENCRYPTION_ID: usize = 14;
+/// sha1WithRSAEncryption bytes in DER
+pub const ALGO_SHA384_WITH_RSA_ENCRYPTION_HEX: [u8; 9] =
+    [0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0c];
+///sha1WithRSAEncryption dot notation
+pub const ALGO_SHA384_WITH_RSA_ENCRYPTION_DOT: &str = "1.2.840.113549.1.1.12";
+///sha1WithRSAEncryption asn1 notation
+pub const ALGO_SHA384_WITH_RSA_ENCRYPTION_NAME: &str =
+    "{iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) pkcs-1(1) sha384WithRSAEncryption(12)}";
+
 lazy_static! {
     /// search oid index by oid binary
     pub static ref OID_MAP: HashMap<Bytes, usize> = vec![
@@ -194,12 +204,13 @@ lazy_static! {
         (OCSP_RESPONSE_BASIC_HEX.to_vec(), OCSP_RESPONSE_BASIC_ID),
         (ALGO_SHA256_WITH_RSA_ENCRYPTION_HEX.to_vec(), ALGO_SHA256_WITH_RSA_ENCRYPTION_ID),
         (ALGO_SHA256_WITH_ECDSA_ENCRYPTION_HEX.to_vec(), ALGO_SHA256_WITH_ECDSA_ENCRYPTION_ID),
+        (ALGO_SHA384_WITH_RSA_ENCRYPTION_HEX.to_vec(), ALGO_SHA384_WITH_RSA_ENCRYPTION_ID),
     ]
     .into_iter()
     .collect();
 
     /// list of ocsp extension oid names
-    pub static ref OCSP_OID_NAME_LIST: [&'static str; 14] = [
+    pub static ref OCSP_OID_NAME_LIST: [&'static str; 15] = [
         OCSP_EXT_NONCE_NAME,
         OCSP_EXT_CRLREF_NAME,
         OCSP_EXT_RESP_TYPE_NAME,
@@ -214,10 +225,11 @@ lazy_static! {
         OCSP_RESPONSE_BASIC_NAME,
         ALGO_SHA256_WITH_RSA_ENCRYPTION_NAME,
         ALGO_SHA256_WITH_ECDSA_ENCRYPTION_NAME,
+        ALGO_SHA384_WITH_RSA_ENCRYPTION_NAME,
     ];
 
     /// list of ocsp extension oid in num dot format
-    pub static ref OCSP_OID_DOT_LIST: [&'static str; 14] = [
+    pub static ref OCSP_OID_DOT_LIST: [&'static str; 15] = [
         OCSP_EXT_NONCE_DOT,
         OCSP_EXT_CRLREF_DOT,
         OCSP_EXT_RESP_TYPE_DOT,
@@ -232,10 +244,11 @@ lazy_static! {
         OCSP_RESPONSE_BASIC_DOT,
         ALGO_SHA256_WITH_RSA_ENCRYPTION_DOT,
         ALGO_SHA256_WITH_ECDSA_ENCRYPTION_DOT,
+        ALGO_SHA384_WITH_RSA_ENCRYPTION_DOT,
     ];
 
     /// list of ocsp extension oid in bytes
-    pub static ref OCSP_OID_HEX_LIST: [Bytes; 14] = [
+    pub static ref OCSP_OID_HEX_LIST: [Bytes; 15] = [
         OCSP_EXT_NONCE_HEX.to_vec(),
         OCSP_EXT_CRLREF_HEX.to_vec(),
         OCSP_EXT_RESP_TYPE_HEX.to_vec(),
@@ -250,6 +263,7 @@ lazy_static! {
         OCSP_RESPONSE_BASIC_HEX.to_vec(),
         ALGO_SHA256_WITH_RSA_ENCRYPTION_HEX.to_vec(),
         ALGO_SHA256_WITH_ECDSA_ENCRYPTION_HEX.to_vec(),
+        ALGO_SHA384_WITH_RSA_ENCRYPTION_HEX.to_vec(),
     ];
 }
 

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -279,6 +279,14 @@ mod test {
         assert_eq!(oid, ALGO_SHA384_WITH_RSA_ENCRYPTION_ID);
     }
 
+    // Test DER to internal ID
+    #[test]
+    fn test_binary2oid() {
+        let hex = ALGO_SHA384_WITH_RSA_ENCRYPTION_HEX;
+        let oid = b2i_oid(&hex).unwrap();
+        assert_eq!(oid, ALGO_SHA384_WITH_RSA_ENCRYPTION_ID);
+    }
+
     // test dot to oid return None for unknown id
     #[test]
     fn test_unknown_oid() {

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -282,7 +282,7 @@ mod test {
     // test dot to oid return None for unknown id
     #[test]
     fn test_unknown_oid() {
-        let dot = "this does not exists, obviously";
+        let dot = "this does not exist, obviously";
         let oid = d2i_oid(dot);
         assert!(oid.is_none());
     }

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -175,7 +175,7 @@ pub const ALGO_SHA256_WITH_ECDSA_ENCRYPTION_NAME: &str =
 /// eg.  
 /// oid_map contains 4 algos [0..3]  
 /// OID_MAX_ID = 3
-pub(crate) const OID_MAX_ID: usize = 14;
+pub(crate) const OID_MAX_ID: usize = 15;
 
 pub(crate) const ALGO_SHA384_WITH_RSA_ENCRYPTION_ID: usize = 14;
 /// sha1WithRSAEncryption bytes in DER
@@ -186,6 +186,16 @@ pub const ALGO_SHA384_WITH_RSA_ENCRYPTION_DOT: &str = "1.2.840.113549.1.1.12";
 ///sha1WithRSAEncryption asn1 notation
 pub const ALGO_SHA384_WITH_RSA_ENCRYPTION_NAME: &str =
     "{iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) pkcs-1(1) sha384WithRSAEncryption(12)}";
+
+pub(crate) const ALGO_SHA384_WITH_ECDSA_ENCRYPTION_ID: usize = 15;
+/// bytes in DER
+pub const ALGO_SHA384_WITH_ECDSA_ENCRYPTION_HEX: [u8; 8] =
+    [0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x03];
+///dot notation
+pub const ALGO_SHA384_WITH_ECDSA_ENCRYPTION_DOT: &str = "1.2.840.10045.4.3.3";
+///asn1 notation
+pub const ALGO_SHA384_WITH_ECDSA_ENCRYPTION_NAME: &str =
+    "{iso(1) member-body(2) us(840) ansi-x962(10045) signatures(4) ecdsa-with-SHA2(3) ecdsa-with-SHA384(3)}";
 
 lazy_static! {
     /// search oid index by oid binary
@@ -205,12 +215,13 @@ lazy_static! {
         (ALGO_SHA256_WITH_RSA_ENCRYPTION_HEX.to_vec(), ALGO_SHA256_WITH_RSA_ENCRYPTION_ID),
         (ALGO_SHA256_WITH_ECDSA_ENCRYPTION_HEX.to_vec(), ALGO_SHA256_WITH_ECDSA_ENCRYPTION_ID),
         (ALGO_SHA384_WITH_RSA_ENCRYPTION_HEX.to_vec(), ALGO_SHA384_WITH_RSA_ENCRYPTION_ID),
+        (ALGO_SHA384_WITH_ECDSA_ENCRYPTION_HEX.to_vec(), ALGO_SHA384_WITH_ECDSA_ENCRYPTION_ID),
     ]
     .into_iter()
     .collect();
 
     /// list of ocsp extension oid names
-    pub static ref OCSP_OID_NAME_LIST: [&'static str; 15] = [
+    pub static ref OCSP_OID_NAME_LIST: [&'static str; 16] = [
         OCSP_EXT_NONCE_NAME,
         OCSP_EXT_CRLREF_NAME,
         OCSP_EXT_RESP_TYPE_NAME,
@@ -226,10 +237,11 @@ lazy_static! {
         ALGO_SHA256_WITH_RSA_ENCRYPTION_NAME,
         ALGO_SHA256_WITH_ECDSA_ENCRYPTION_NAME,
         ALGO_SHA384_WITH_RSA_ENCRYPTION_NAME,
+        ALGO_SHA384_WITH_ECDSA_ENCRYPTION_NAME,
     ];
 
     /// list of ocsp extension oid in num dot format
-    pub static ref OCSP_OID_DOT_LIST: [&'static str; 15] = [
+    pub static ref OCSP_OID_DOT_LIST: [&'static str; 16] = [
         OCSP_EXT_NONCE_DOT,
         OCSP_EXT_CRLREF_DOT,
         OCSP_EXT_RESP_TYPE_DOT,
@@ -245,10 +257,11 @@ lazy_static! {
         ALGO_SHA256_WITH_RSA_ENCRYPTION_DOT,
         ALGO_SHA256_WITH_ECDSA_ENCRYPTION_DOT,
         ALGO_SHA384_WITH_RSA_ENCRYPTION_DOT,
+        ALGO_SHA384_WITH_ECDSA_ENCRYPTION_DOT,
     ];
 
     /// list of ocsp extension oid in bytes
-    pub static ref OCSP_OID_HEX_LIST: [Bytes; 15] = [
+    pub static ref OCSP_OID_HEX_LIST: [Bytes; 16] = [
         OCSP_EXT_NONCE_HEX.to_vec(),
         OCSP_EXT_CRLREF_HEX.to_vec(),
         OCSP_EXT_RESP_TYPE_HEX.to_vec(),
@@ -264,6 +277,7 @@ lazy_static! {
         ALGO_SHA256_WITH_RSA_ENCRYPTION_HEX.to_vec(),
         ALGO_SHA256_WITH_ECDSA_ENCRYPTION_HEX.to_vec(),
         ALGO_SHA384_WITH_RSA_ENCRYPTION_HEX.to_vec(),
+        ALGO_SHA384_WITH_ECDSA_ENCRYPTION_HEX.to_vec(),
     ];
 }
 

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -175,7 +175,7 @@ pub const ALGO_SHA256_WITH_ECDSA_ENCRYPTION_NAME: &str =
 /// eg.  
 /// oid_map contains 4 algos [0..3]  
 /// OID_MAX_ID = 3
-pub(crate) const OID_MAX_ID: usize = 13;
+pub(crate) const OID_MAX_ID: usize = 14;
 
 pub(crate) const ALGO_SHA384_WITH_RSA_ENCRYPTION_ID: usize = 14;
 /// sha1WithRSAEncryption bytes in DER

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,5 @@
 //! OCSP response  
-use tracing::{error, info, trace, warn};
+use tracing::{error, trace, warn};
 
 use crate::common::asn1::Bytes;
 use crate::common::{
@@ -381,13 +381,13 @@ impl BasicResponse {
         pad.extend(&self.signature);
         v.extend(asn1_encode_bit_string(&pad)?);
         if let Some(certs) = &self.certs {
-            let d =
-                yasna::construct_der_seq(|w| {
-                    w.next().write_sequence_of(|w| 
-                        for c in certs {
-                            w.next().write_der(c)
-                        })
-                    });
+            let d = yasna::construct_der_seq(|w| {
+                w.next().write_sequence_of(|w| {
+                    for c in certs {
+                        w.next().write_der(c)
+                    }
+                })
+            });
             let tag = yasna::Tag::context(0);
             let pc = yasna::PCBit::Constructed;
             let tv = yasna::models::TaggedDerValue::from_tag_pc_and_bytes(tag, pc, d);

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,5 @@
 //! OCSP response  
-use tracing::{error, trace, warn};
+use tracing::{error, info, trace, warn};
 
 use crate::common::asn1::Bytes;
 use crate::common::{


### PR DESCRIPTION
Hi,

First of all, thank you for this fork. I have added support for SHA384 with both RSA and ECDSA encyption which i needed.
I have also made some changes and additions to your OCSP-server proyect, which i may sync soon. But these changes need to be merged first.

Your projects really helped me to understand how OCSP really works in practice. I will centainly be using both of the projects for my private use.

Thank you!